### PR TITLE
lower overhead from optimization prevention mesures in loop.c

### DIFF
--- a/cvm/loop.c
+++ b/cvm/loop.c
@@ -3,9 +3,10 @@
 #include <stdio.h>
 
 int main(void) {
-    volatile int64_t counter = 1000000000;
-    while (counter !=0) {
+    int64_t counter = 1000000000;
+    while (counter != 0) {
         counter--;
+        asm volatile ("");
     }
     printf("Counter: %" PRId64 "\n", counter);
     return 0;


### PR DESCRIPTION
This reduce the overhead from `volatile` while keeping the loop around.